### PR TITLE
Mechanisme pour contourner l'authorisation - visibilite des pages

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,0 +1,2 @@
+//https://stackoverflow.com/questions/49579028/adding-an-env-file-to-react-project
+REACT_APP_BYPASS_AUTH=true

--- a/client/.env
+++ b/client/.env
@@ -1,2 +1,2 @@
 //https://stackoverflow.com/questions/49579028/adding-an-env-file-to-react-project
-REACT_APP_BYPASS_AUTH=true
+REACT_APP_BYPASS_AUTH=false

--- a/client/src/components/MainMenu.tsx
+++ b/client/src/components/MainMenu.tsx
@@ -27,8 +27,7 @@ const MainMenu = () => {
         {
             path: '/service',
             text: 'Service',
-            isVisible: () =>
-                isAuthorized() && auth?.user?.roles?.includes(UserRole.LEADER),
+            isVisible: () => isAuthorized() && isLeader(),
         },
         {
             path: '/dev',
@@ -38,7 +37,16 @@ const MainMenu = () => {
     ];
 
     function isAuthorized() {
-        return auth?.user != null;
+        return (
+            auth?.user != null || process.env.REACT_APP_BYPASS_AUTH === 'true'
+        );
+    }
+
+    function isLeader() {
+        return (
+            auth?.user?.roles?.includes(UserRole.LEADER) ||
+            process.env.REACT_APP_BYPASS_AUTH === 'true'
+        );
     }
 
     const [selectedKey, setSelectedKey] = useState(menuEntriesList[0].path);

--- a/client/src/utility/RequireAuth.tsx
+++ b/client/src/utility/RequireAuth.tsx
@@ -5,7 +5,7 @@ export function RequireAuth({ children }: { children: JSX.Element }) {
     const auth = useAuth();
     const location = useLocation();
 
-    if (!auth || !auth.user) {
+    if ((!auth || !auth.user) && process.env.REACT_APP_BYPASS_AUTH !== 'true') {
         // Redirect them to the /login page, but save the current location they were
         // trying to go to when they were redirected. This allows us to send them
         // along to that page after they login, which is a nicer user experience

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "scripts": {
         "test": "jest --detectOpenHandles --verbose",
-        "dev": "nodemon src/app.ts",
+        "start": "nodemon src/app.ts",
         "lint": "eslint --fix --ext .ts,.tsx .",
         "prettier": "prettier --write src/**/*.{ts,tsx}"
     },

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -20,9 +20,9 @@ app.use('/auth', authRouter);
 app.use('/dev', devRouter);
 
 app.use(requireAuthToken);
-app.use('/service');
-app.use('/user');
-app.use('/note');
+// app.use('/service');
+// app.use('/user');
+// app.use('/note');
 
 const opts = {
     bufferCommands: false,


### PR DESCRIPTION
Maintenant si on est pas connecté, alors certaines pages sont bloquées (les liens n'apparaissent pas dans le menu et si on met les urls correspondant alors on est redirigé vers la page de connexion). Si on veut désactiver cette fonctionnalité (pour faire les prototypes de l’interface) on peut mettre le paramètre **REACT_APP_BYPASS_AUTH** qui se trouve dans le fichier _.env_ du client en **true**.